### PR TITLE
Add: MIDIfile save function and new requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ here = path.abspath(path.dirname(__file__))
 
 VERSION = None
 REQUIREMENTS = [
+    'numpy<=1.19.2'
     'pygame==1.9.3',
     'pretty_midi',
     'midiutil'


### PR DESCRIPTION
I added a function to save midifile that includes parts of _play_midi_from_data( )_ and _write_to_midifile( )_ I find this interesting when someone wants to sonify data with loops (76 items for example). 

![Captura](https://user-images.githubusercontent.com/49756923/115976149-96af0d80-a530-11eb-9880-64984872eb6a.PNG)


I also added a new requirement because numpy version 1.20 requires python 3.7.
I tried install sonify in a conda env with python 3.7 and I couldn't.


